### PR TITLE
Fix unable to load container at startup

### DIFF
--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -15,6 +15,8 @@ COPY files/sshd_config /etc/ssh/sshd_config
 COPY files/create-sftp-user /usr/local/bin/
 COPY files/entrypoint /
 
+RUN chmod +x /entrypoint
+
 EXPOSE 22
 
 ENTRYPOINT ["/entrypoint"]


### PR DESCRIPTION
Fix a startup issue with error message: docker: Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "/entrypoint": permission denied: unknown.